### PR TITLE
Enable extract-path on nodes.

### DIFF
--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -52,6 +52,9 @@ When RESULT is non-NIL, the others are NIL. When result is NIL however, the othe
 In the case of complete failure, where even the very first item on KEY-LIST does not
 match the top XML form given, all three return values are NIL.  (It suffices to check
 the first two return values.)"
+  (when (typep xml 'node)
+    (setf xml
+          (node->nodelist xml)))
   (labels ((find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond

--- a/fiveam-tests.lisp
+++ b/fiveam-tests.lisp
@@ -95,3 +95,51 @@
       (is (equalp result
                   '(("article-title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") NIL
                     "HNS, a nuclearcytoplasmic shuttling sequence in HuR"))))))
+
+(def-fixture parsed-article-struct ()
+  (let ((node
+          (with-open-file (str (asdf:system-relative-pathname "xmls" "tests/nxml/genetics-article.xml")
+                               :direction :input)
+            (xmls:parse str))))
+    (&body)))
+
+(test check-extract-path-from-structs
+  (with-fixture parsed-article-struct ()
+    ;; retrieve first of items matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" "ref")
+                                     node)))
+      (is (= 4 (length result)))
+      (is (equalp (nth 0 result)
+                  '("ref" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle")))
+      (is (equalp (nth 1 result)
+                  '(("id" "gkt903-B1")))))
+
+    ;; retrieve tag attributes of first item matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" "ref" . *)
+                                     node)))
+      (is (equalp result
+                  '(("id" "gkt903-B1")))))
+
+    ;; retrieve all items enclosed by element matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" *)
+                                     node)))
+      (is (= 41 (length result)))
+      (is (equalp (nth 0 result)
+                  '(("title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") nil "REFERENCES")))
+      (is (equalp (nth 1 (nth 1 result))
+                  '(("id" "gkt903-B1"))))
+      (is (equalp (nth 1 (nth 15 result))
+                  '(("id" "gkt903-B15")))))
+
+    ;; select specific item among several with same tag based on tag attributes
+    ;; here selecting on "ref" in the path...
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" ("ref" ("id" "gkt903-B15")) "element-citation"
+                                       "article-title")
+                                     node)))
+      (is (equalp result
+                  '(("article-title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") NIL
+                    "HNS, a nuclearcytoplasmic shuttling sequence in HuR"))))))


### PR DESCRIPTION
Check to see if the XML argument to EXTRACT-PATH is a NODE structure, and if so, translate it into a nodelist to enable EXTRACT-PATH to process it.
Added a FiveAM test.